### PR TITLE
fixed breadcrumb, searchDropDown, pagination, filters link

### DIFF
--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -9,12 +9,12 @@ import { Props } from '@components/breadcrumb/types';
 import styles from '@components/breadcrumb/Breadcrumb.module.scss';
 
 const list: Record<string, string> = {
-  Mouse: 'Mouse',
+  Mouse: 'Mice',
   'Mouse Pad': 'Mouse mats',
-  Keyboard: 'Keyboard',
-  Joystick: 'Joystick and controller',
+  Keyboard: 'Keyboards',
+  Joystick: 'Joysticks and controllers',
   Headset: 'Headsets',
-  'Gaming Chairs': 'Gaming chairs',
+  'Gaming Chair': 'Gaming chairs',
 };
 
 const Breadcrumb: FC<Props> = ({ category, name }) => {
@@ -39,7 +39,7 @@ const Breadcrumb: FC<Props> = ({ category, name }) => {
           href="/"
         />
         <ArrowRight size="small" />
-        <Link to={`/catalog/${category}`}>{newCat}</Link>
+        <Link to={`/catalog/${category}`}>{category}</Link>
         {name && (
           <>
             <ArrowRight size="small" />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -16,7 +16,7 @@ import styles from '@components/header/Header.module.scss';
 
 const Header: FC = () => {
   const [isVisibleSearch, setVisibleSearch] = useState<boolean>(false);
-  const toggleButtonRef = useRef(null);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
 
   const favoriteCount = 999;
   const cartCount = 15;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 
 import DropDownMenu from '@components/header/dropDownMenu/DropDownMenu';
 import DropDownSearch from '@components/header/dropDownSearch/DropDownSearch';
@@ -16,6 +16,7 @@ import styles from '@components/header/Header.module.scss';
 
 const Header: FC = () => {
   const [isVisibleSearch, setVisibleSearch] = useState<boolean>(false);
+  const toggleButtonRef = useRef(null);
 
   const favoriteCount = 999;
   const cartCount = 15;
@@ -43,10 +44,13 @@ const Header: FC = () => {
         </div>
         <div className={styles['icons']}>
           <IconButton
+            ref={toggleButtonRef}
             type="button"
             className="link-gray large"
             icon={<Search size="medium" />}
-            onClick={() => setVisibleSearch(!isVisibleSearch)}
+            onClick={() =>
+              isVisibleSearch ? setVisibleSearch(false) : setVisibleSearch(true)
+            }
           />
           <IconButton
             type="button"
@@ -78,10 +82,13 @@ const Header: FC = () => {
             )}
           </div>
         </div>
-        <DropDownSearch
-          onClick={() => setVisibleSearch(!isVisibleSearch)}
-          isVisible={isVisibleSearch}
-        />
+        {isVisibleSearch && (
+          <DropDownSearch
+            onClick={() => setVisibleSearch(false)}
+            isVisible={isVisibleSearch}
+            toggleRef={toggleButtonRef}
+          />
+        )}
       </header>
     </Container>
   );

--- a/src/components/header/dropDownItem/DropDownItem.tsx
+++ b/src/components/header/dropDownItem/DropDownItem.tsx
@@ -9,13 +9,21 @@ import { Props } from '@components/header/dropDownItem/types';
 
 import styles from '@components/header/dropDownItem/DropDownItem.module.scss';
 
-const DropDownItem: FC<Props> = ({ icon, text, href, isNew, listItem }) => {
+const DropDownItem: FC<Props> = ({
+  icon,
+  text,
+  href,
+  isNew,
+  listItem,
+  onClick,
+}) => {
   return (
     <Link
       to={href}
       className={`${styles['drop-down-item']} ${
         listItem ? styles['list-item'] : ''
       }`}
+      onClick={onClick}
     >
       <div className={styles['text-badge']}>
         {icon ? icon : <Search size="small" />}

--- a/src/components/header/dropDownItem/types.ts
+++ b/src/components/header/dropDownItem/types.ts
@@ -6,4 +6,5 @@ export interface Props {
   href: string;
   isNew?: boolean;
   listItem?: boolean;
+  onClick?: () => void;
 }

--- a/src/components/header/dropDownSearch/DropDownSearch.tsx
+++ b/src/components/header/dropDownSearch/DropDownSearch.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 
 import Search from '@components/icons/Search';
 import CloseBig from '@components/icons/CloseBig';
@@ -36,8 +36,9 @@ const items = [
   },
 ];
 
-const DropDownSearch: FC<Props> = ({ onClick, isVisible }) => {
+const DropDownSearch: FC<Props> = ({ onClick, isVisible, toggleRef }) => {
   const [value, setValue] = useState<string>('');
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -48,11 +49,29 @@ const DropDownSearch: FC<Props> = ({ onClick, isVisible }) => {
     onClick();
   };
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node) &&
+        !toggleRef.current?.contains(event.target as Node) &&
+        isVisible
+      ) {
+        handleCloseClick();
+      }
+    };
+
+    document.addEventListener('mouseup', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mouseup', handleClickOutside);
+    };
+  }, [containerRef, handleCloseClick, isVisible, toggleRef]);
+
   return (
     <div
-      className={`${styles['search-container']} ${
-        isVisible ? styles.visible : ''
-      }`}
+      ref={containerRef}
+      className={`${styles['search-container']} ${styles.visible}`}
     >
       <div className={styles['search-header-container']}>
         <CustomInput
@@ -77,6 +96,7 @@ const DropDownSearch: FC<Props> = ({ onClick, isVisible }) => {
               text={item.text}
               href={item.href}
               listItem
+              onClick={handleCloseClick}
             />
           ))}
         </div>

--- a/src/components/header/dropDownSearch/types.ts
+++ b/src/components/header/dropDownSearch/types.ts
@@ -1,4 +1,7 @@
+import { MutableRefObject } from 'react';
+
 export interface Props {
   onClick: () => void;
   isVisible: boolean;
+  toggleRef: MutableRefObject<null | HTMLButtonElement>;
 }

--- a/src/components/iconButton/IconButton.tsx
+++ b/src/components/iconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React from 'react';
 
 import { generateClassNames } from '@utils/generateClassNames/className';
 
@@ -6,25 +6,24 @@ import { Props } from '@components/iconButton/types';
 
 import styles from '@components/iconButton/IconButton.module.scss';
 
-const IconButton: FC<Props> = ({
-  className,
-  icon,
-  type,
-  isDisabled,
-  onClick,
-}) => {
-  const buttonClassNames = generateClassNames(className, styles);
+const IconButton = React.forwardRef<HTMLButtonElement, Props>(
+  ({ className, icon, type, isDisabled, onClick }, ref) => {
+    const buttonClassNames = generateClassNames(className, styles);
 
-  return (
-    <button
-      className={buttonClassNames}
-      type={type}
-      onClick={onClick}
-      disabled={isDisabled}
-    >
-      {icon}
-    </button>
-  );
-};
+    return (
+      <button
+        ref={ref}
+        className={buttonClassNames}
+        type={type}
+        onClick={onClick}
+        disabled={isDisabled}
+      >
+        {icon}
+      </button>
+    );
+  },
+);
+
+IconButton.displayName = 'IconButton';
 
 export default IconButton;

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -10,7 +10,13 @@ import { Props } from '@components/pagination/types';
 import styles from '@components/pagination/Pagination.module.scss';
 
 const Pagination: FC<Props> = ({ pages, currentPage, setCurrentPage }) => {
-  const pageNumbers = Array.from({ length: pages }, (_, index) => index + 1);
+  const pageNumbers: number[] = Array.from(
+    { length: pages },
+    (_, index) => index + 1,
+  );
+
+  const firstPage: number = currentPage[0];
+  const lastPage: number = currentPage[currentPage.length - 1];
 
   const getPageSubset = () => {
     if (pages <= 6) {
@@ -55,6 +61,7 @@ const Pagination: FC<Props> = ({ pages, currentPage, setCurrentPage }) => {
         className="link-gray small"
         text="Previous"
         onClick={() => changePage(true, false)}
+        isDisabled={firstPage === 1}
       />
       <div className={styles['pages']}>
         {getPageSubset().map((pageNumber, index) => (
@@ -72,6 +79,7 @@ const Pagination: FC<Props> = ({ pages, currentPage, setCurrentPage }) => {
         className="link-gray small"
         text="Next"
         onClick={() => changePage(false, true)}
+        isDisabled={lastPage === pages}
       />
     </div>
   );

--- a/src/pages/catalog/sideBar/SideBar.tsx
+++ b/src/pages/catalog/sideBar/SideBar.tsx
@@ -187,7 +187,6 @@ const SideBar: FC<Props> = ({ loadProduct }) => {
   return (
     <div className={styles['sidebar-container']}>
       <h6>Filters:</h6>
-      <button onClick={() => console.log(catalog)}>111</button>
       <DropDown header="Price">
         <RangeSlider
           priceMin={newFilters?.price.min_price || 0}

--- a/src/pages/catalog/sideBar/SideBar.tsx
+++ b/src/pages/catalog/sideBar/SideBar.tsx
@@ -36,7 +36,9 @@ const SideBar: FC<Props> = ({ loadProduct }) => {
   const fetchData = async (request?: string) => {
     try {
       const queryString = request ? `&${request}` : '';
-      const url = `http://localhost:8080/products/filters?category.name=${category}${queryString}`;
+      const url = `http://localhost:8080/products/filters?category.name=${
+        category === 'Mouse Pad' ? 'Pad' : category
+      }${queryString}`;
 
       const response = await fetch(url);
 
@@ -87,7 +89,7 @@ const SideBar: FC<Props> = ({ loadProduct }) => {
     };
 
     setData();
-  }, []);
+  }, [category]);
 
   const renderCharacteristics = (
     mainObject: Record<string, string[]>,
@@ -185,6 +187,7 @@ const SideBar: FC<Props> = ({ loadProduct }) => {
   return (
     <div className={styles['sidebar-container']}>
       <h6>Filters:</h6>
+      <button onClick={() => console.log(catalog)}>111</button>
       <DropDown header="Price">
         <RangeSlider
           priceMin={newFilters?.price.min_price || 0}

--- a/src/store/slices/catalog/catalogReducers.ts
+++ b/src/store/slices/catalog/catalogReducers.ts
@@ -38,7 +38,7 @@ export const setSortBy = (
   state: CatalogState,
   action: PayloadAction<string>,
 ) => {
-  state.sortBy = action.payload;
+  state.sortBy = `sort=${action.payload}`;
 };
 
 export const toggleSale = (state: CatalogState) => {


### PR DESCRIPTION
Fixed bugs:
- The user cannot close the searching window clicking outside
- Unsynchronised headings in the block Shop by category
- The button previous in the pagination is visible even if the user is on the first page
- The button "next" in the pagination is visible even if the user is on the last page
- Filters category not load when change category from category Page